### PR TITLE
Remove LZ4 from target include directories

### DIFF
--- a/gen/cpp/creator_test.go
+++ b/gen/cpp/creator_test.go
@@ -86,7 +86,6 @@ add_library(Resource STATIC
 
 target_include_directories(Resource PUBLIC
   ${CMAKE_CURRENT_LIST_DIR}
-  ${LZ4F_INCLUDE_DIR}
 )
 
 target_link_libraries(Resource LZ4F)

--- a/gen/cpp/templates.go
+++ b/gen/cpp/templates.go
@@ -329,7 +329,6 @@ add_library(Resource STATIC
 
 target_include_directories(Resource PUBLIC
   ${CMAKE_CURRENT_LIST_DIR}
-  ${LZ4F_INCLUDE_DIR}
 )
 
 target_link_libraries(Resource LZ4F)


### PR DESCRIPTION
`Resource` doesn't expose LZ4 names in its interface.