### PR TITLE
Add phx gen --skip-finalize, track impls in CMake

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -168,7 +168,7 @@
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "63cb32ae39b28d6bb8e7e215c1fc39dd80dcdb02"
+  revision = "6d18c012aee9febd81bbf9806760c8c4480e870d"
 
 [[projects]]
   digest = "1:1093f2eb4b344996604f7d8b29a16c5b22ab9e1b25652140d3fede39f640d5cd"

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -26,12 +26,14 @@ import (
 )
 
 var (
-	from = new(string)
-	to   = new(string)
+	from string
+	to   string
 
 	match Regexp
 
-	level = new(int)
+	skipFinalize bool
+
+	level int
 )
 
 // genCmd represents the gen command
@@ -41,8 +43,8 @@ var genCmd = &cobra.Command{
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		pipeline := gen.Gen{
-			From: fs.Real{Where: *from},
-			To:   fs.Real{Where: *to},
+			From: fs.Real{Where: from},
+			To:   fs.Real{Where: to},
 
 			Matcher: func() path.Matcher {
 				if match.Regexp == nil {
@@ -51,8 +53,10 @@ var genCmd = &cobra.Command{
 				return match
 			}(),
 
+			SkipFinalize: skipFinalize,
+
 			Level: func() compress.Level {
-				switch *level {
+				switch level {
 				case 0:
 					return compress.Fastest
 				case 1:
@@ -85,19 +89,24 @@ func init() {
 	)
 
 	genCmd.PersistentFlags().StringVar(
-		from, "from",
+		&from, "from",
 		"res",
 		"Where to read static resources",
 	)
 	genCmd.PersistentFlags().StringVar(
-		to, "to",
+		&to, "to",
 		"gen",
 		"Where to write generated resources",
 	)
 
 	genCmd.PersistentFlags().IntVarP(
-		level, "level", "l",
+		&level, "level", "l",
 		0,
 		"The compression level to use (0, 1, 2, 3, 9)",
+	)
+
+	genCmd.PersistentFlags().BoolVar(
+		&skipFinalize, "skip-finalize", false,
+		"Don't finalize generated files",
 	)
 }

--- a/gen/cpp/creator_test.go
+++ b/gen/cpp/creator_test.go
@@ -73,15 +73,34 @@ cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
 # Add LZ4 and LZ4F definitions.
 add_subdirectory(lz4/lib)
 
+set_source_files_properties(
+  res/al_gif_decl.cxx
+  res/al_gif_real.cxx
+  res/al_jpg_decl.cxx
+  res/al_jpg_real.cxx
+  res/bob_gif_decl.cxx
+  res/bob_gif_real.cxx
+  res/bob_jpg_decl.cxx
+  res/bob_jpg_real.cxx
+
+  PROPERTIES
+    GENERATED True
+    HEADER_FILE_ONLY ON
+)
+
 # Add Resource library.
 add_library(Resource STATIC
   mapper.cxx
   mappings.cxx
   resource.cxx
   res/al_gif_decl.cxx
+  res/al_gif_real.cxx
   res/al_jpg_decl.cxx
+  res/al_jpg_real.cxx
   res/bob_gif_decl.cxx
+  res/bob_gif_real.cxx
   res/bob_jpg_decl.cxx
+  res/bob_jpg_real.cxx
 )
 
 target_include_directories(Resource PUBLIC

--- a/gen/cpp/templates.go
+++ b/gen/cpp/templates.go
@@ -309,12 +309,21 @@ namespace res {
 `[1:]
 
 var cmakeTmp = `
-{{define "expand"}}  res/{{.VarName}}_decl.cxx{{end}}`[1:] + `
+{{define "expand"}}  res/{{.VarName}}_decl.cxx
+  res/{{.VarName}}_real.cxx{{end}}`[1:] + `
 
 cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
 
 # Add LZ4 and LZ4F definitions.
 add_subdirectory(lz4/lib)
+
+set_source_files_properties(
+{{range .}}{{template "expand" .}}
+{{end}}
+  PROPERTIES
+    GENERATED True
+    HEADER_FILE_ONLY ON
+)
 
 # Add Resource library.
 add_library(Resource STATIC

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -22,6 +22,8 @@ type Gen struct {
 	From, To fs.FS
 	compress.Level
 
+	SkipFinalize bool
+
 	path.Matcher
 	// TODO: Verbosity
 }
@@ -103,9 +105,11 @@ func (g Gen) Operate() error {
 
 	tw.Flush()
 
-	if err := encoder.Finalize(); err != nil {
+	if !g.SkipFinalize {
 		// Do any last synchronous cleanup the Encoder requires.
-		return errors.Wrap(err, "finalizing Encoder")
+		if err := encoder.Finalize(); err != nil {
+			return errors.Wrap(err, "finalizing Encoder")
+		}
 	}
 
 	// All finished tmpfiles are now in the tmp destination and


### PR DESCRIPTION
When using `phx gen` to recompile shaders in a CMake pipeline, obliterating and rewriting CMakeLists.txt causes the project to be reloaded.  Now, passing `--skip-finalize` only writes out the implementation files.

Additionally, the implementation files are tracked in CMakeLists.txt now, so hopefully CMake will be better at detecting changes.