### PR TITLE
Revert "Make phx gen create a SHARED library"

### DIFF
--- a/gen/cpp/creator_test.go
+++ b/gen/cpp/creator_test.go
@@ -111,7 +111,7 @@ set_source_files_properties(
 )
 
 # Add Resource library.
-add_library(Resource SHARED)
+add_library(Resource STATIC)
 
 target_sources(Resource
   PUBLIC

--- a/gen/cpp/templates.go
+++ b/gen/cpp/templates.go
@@ -331,7 +331,7 @@ set_source_files_properties(
 )
 
 # Add Resource library.
-add_library(Resource SHARED)
+add_library(Resource STATIC)
 
 target_sources(Resource
   PUBLIC


### PR DESCRIPTION
Reverts phoenix-engine/phx#35 because it breaks the build.